### PR TITLE
Force population of _result_cache by adding test for valid len

### DIFF
--- a/tests/cases/models/tests.py
+++ b/tests/cases/models/tests.py
@@ -30,6 +30,9 @@ class ModelInstanceCacheTestCase(TestCase):
         self.is_manager.save()
 
         queryset = DataField.objects.filter(pk=pk)
+        # Without this len test, the _result_cache will not be populated due to
+        # the inherent laziness of the filter method.
+        self.assertGreater(len(queryset), 0)
         self.assertEqual(queryset._result_cache[0].pk, pk)
 
 


### PR DESCRIPTION
Previously, [this test](https://github.com/cbmi/avocado/blob/2.x/tests/cases/models/tests.py#L32-L33) in the DataField cache test would fail because the _result_cache is not populated since filter does not set that property of the QuerySet object. It is not set until a
method is called that forces it to be set so by calling [len](https://github.com/django/django/blob/master/django/db/models/query.py#L89-L92) we will force _result_cache to be set and also allow us to test and make sure we got something back from our filter call.
