### PR TITLE
Change internal structure of DataView to be 'facet'-based

### DIFF
--- a/avocado/query/oldparsers/dataview.py
+++ b/avocado/query/oldparsers/dataview.py
@@ -1,36 +1,58 @@
-import warnings
+from warnings import warn
 try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
 from modeltree.tree import trees
 from modeltree.query import ModelTreeQuerySet
-from django.core.exceptions import ValidationError
 
 
 SORT_DIRECTIONS = ('asc', 'desc')
 
 
-def has_keys(obj, keys):
-    "Check the required keys are present in `obj`"
-    for key in keys:
-        if key not in obj:
-            return False
-    return True
-
-
 class Node(object):
-    def __init__(self, columns=None, ordering=None, **context):
-        self.concept_ids = columns or []
-        self.ordering = ordering or []
+    def __init__(self, facets=None, **context):
+        self.facets = facets or []
         self.tree = context.pop('tree', None)
         self.context = context
 
+    @property
+    def concept_ids(self):
+        ids = []
+        for facet in self.facets:
+            if facet.get('enabled') is False:
+                continue
+            if facet.get('visible') is False:
+                continue
+            ids.append(facet['concept'])
+        return ids
+
+    @property
+    def ordering(self):
+        ids = []
+        length = len(self.facets)
+        for facet in self.facets:
+            if facet.get('enabled') is False:
+                continue
+            if facet.get('sort') in SORT_DIRECTIONS:
+                # If sort is not defined, default to length of facets
+                ids.append((
+                    facet.get('sort_index', length),
+                    facet['concept'],
+                    facet['sort'],
+                ))
+        # Sort relative to sort index
+        ids.sort(key=lambda x: x[0])
+        # Return only the concept id and sort direction
+        return [(c, s) for i, c, s in ids]
+
     def _get_concepts(self, ids):
         "Returns an ordered list of concepts based on `ids`."
-        from avocado.models import DataConcept
         if not ids:
             return []
+
+        from avocado.models import DataConcept
+
         concepts = list(DataConcept.objects.filter(pk__in=ids))
         concepts.sort(key=lambda o: ids.index(o.pk))
         return concepts
@@ -66,12 +88,13 @@ class Node(object):
         # returned will include this extra data. The exporter classes handle
         # this by removing redundant rows relative to the *original* columns.
         ids = list(self.concept_ids)
-        if self.ordering and distinct:
-            ids += list(zip(*self.ordering)[0])
+        ordering = self.ordering
+        if ordering and distinct:
+            ids += list(zip(*ordering)[0])
 
         # Flatten the grouped fields
-        fields = \
-            [i for l in self._get_fields_for_concepts(ids).values() for i in l]
+        fields = [i for l in self._get_fields_for_concepts(ids).values()
+                  for i in l]
 
         model_fields = []
 
@@ -85,13 +108,14 @@ class Node(object):
     def _get_order_by(self):
         "Returns directional lookups to be unpacked in `QuerySet.order_by`."
         order_by = []
+        ordering = self.ordering
 
-        if self.ordering:
+        if ordering:
             tree = trees[self.tree]
-            ids, directions = zip(*self.ordering)
+            ids, directions = zip(*ordering)
             groups = self._get_fields_for_concepts(ids)
 
-            for pk, direction in self.ordering:
+            for pk, direction in ordering:
                 for f in groups[pk]:
                     # Special case for Lexicon-based models, order by their
                     # model-defined `order` field.
@@ -137,52 +161,112 @@ class Node(object):
 
     def get_concepts_for_order_by(self):
         ids = []
-        if self.ordering:
-            ids = zip(*self.ordering)[0]
+        ordering = self.ordering
+        if ordering:
+            ids = zip(*ordering)[0]
         return self._get_concepts(ids)
 
     def get_fields_for_order_by(self):
         ids = []
-        if self.ordering:
-            ids = zip(*self.ordering)[0]
+        ordering = self.ordering
+        if ordering:
+            ids = zip(*ordering)[0]
         return self._get_fields_for_concepts(ids)
 
-    @property
-    def columns(self):
-        warnings.warn('This property has been deprecated, used '
-                      'get_concepts_for_select() instead', DeprecationWarning)
-        return self.get_concepts_for_select()
 
-
-def validate(attrs, **context):
-    if not attrs:
-        return
-
-    from avocado.models import DataConcept
-
+def convert_legacy(attrs):
+    facets = []
     columns = attrs.get('columns', [])
     ordering = attrs.get('ordering', [])
 
-    if columns:
-        num_concepts = DataConcept.objects.filter(pk__in=columns).count()
-        if len(set(columns)) != num_concepts:
-            raise ValidationError('One or more concepts do not exist')
+    # Map to position
+    _ordering = {}
+    for i, (concept, direction) in enumerate(ordering):
+        _ordering[concept] = i
 
-    if ordering:
-        ids, directions = zip(*ordering)
+    for pk in columns:
+        facet = {'concept': pk}
 
-        for _dir in directions:
-            if _dir.lower() not in SORT_DIRECTIONS:
-                raise ValidationError('Invalid sort direction')
+        if pk in _ordering:
+            index = _ordering.pop(pk)
+            facet['sort'] = ordering[index][1]
+            facet['sort_index'] = index
 
-        if len(set(ids)) != DataConcept.objects.filter(pk__in=ids).count():
-            raise ValidationError('One or more concepts do not exist')
+        facets.append(facet)
+
+    # Append the sort only concepts
+    for pk in _ordering:
+        index = _ordering[pk]
+        facets.append({
+            'visible': False,
+            'concept': pk,
+            'sort': ordering[index][1],
+            'sort_index': index,
+        })
+
+    return facets
 
 
-def parse(attrs, **context):
-    if not attrs:
+def validate(facets, **context):
+    if not facets:
+        return None
+
+    from avocado.models import DataConcept
+
+    # Legacy format
+    if isinstance(facets, dict):
+        warn('The dict-based view structure has been deprecated. '
+             'A list of facets objects must now be provided.',
+             DeprecationWarning)
+        facets = convert_legacy(facets)
+
+    for attrs in facets:
+        enabled = attrs.pop('enabled', None)
+        attrs.pop('errors', None)
+        attrs.pop('warnings', None)
+        errors = []
+        warnings = []
+
+        concept = None
+
+        if 'concept' not in attrs:
+            enabled = False
+            errors.append('Concept is required')
+        else:
+            try:
+                concept = DataConcept.objects.get(pk=attrs.get('concept'))
+            except DataConcept.DoesNotExist:
+                enabled = False
+                errors.append('Concept does not exist')
+
+        if 'sort' in attrs and attrs['sort'] not in SORT_DIRECTIONS:
+            warnings.append('Invalid sort direction. Must be "asc" or "desc"')
+
+        if concept and not concept.sortable:
+            warnings.append('Cannot sort by concept')
+
+        if enabled is False:
+            attrs['enabled'] = False
+
+        # Amend errors and warnings if present
+        if errors:
+            attrs['errors'] = errors
+
+        if warnings:
+            attrs['warnings'] = warnings
+
+    return facets
+
+
+def parse(facets, **context):
+    if not facets:
         return Node(**context)
 
-    columns = attrs.get('columns', None)
-    ordering = attrs.get('ordering', None)
-    return Node(columns, ordering, **context)
+    # Legacy format
+    if isinstance(facets, dict):
+        warn('The dict-based view structure has been deprecated. '
+             'A list of facets objects must now be provided.',
+             DeprecationWarning)
+        facets = convert_legacy(facets)
+
+    return Node(facets, **context)

--- a/tests/cases/models/tests.py
+++ b/tests/cases/models/tests.py
@@ -295,10 +295,10 @@ class DataQueryTestCase(TestCase):
         }
 
         exp_attrs = deepcopy(attrs)
-        exp_attrs['view'] = None
+        exp_attrs['view'] = [{'concept': 1}]
 
         self.assertEqual(DataQuery.validate(deepcopy(attrs), tree=Employee),
-                exp_attrs)
+                         exp_attrs)
 
     def test_parse(self):
         attrs = {


### PR DESCRIPTION
This was required to implement #81 since there was no way to flag
individual columns in the structure that it was in. This is a more
robust structure composed of a list of dicts each of which with at least
one key 'concept' which is the primary key of the concept the facet
represents.

Each facet can now be disabled if an error occurs while being parsed.
Facets can have their 'visible' attribute set to False to denote this it
is only intended for sorting the data.

This is a backwards compatible change as it works with the previous legacy
input, however the output is in the new structure.

Read more http://avocado.harvest.io/wip/view-facet-validation.html

Resolves #82
Fix #81
