### PR TITLE
Exclude concepts without fields from the ConceptManagers published set

### DIFF
--- a/avocado/managers.py
+++ b/avocado/managers.py
@@ -41,6 +41,8 @@ class DataConceptQuerySet(PublishedQuerySet):
         """Concepts can be restricted to one or more sites, so the published
         method is extended to support filtering by site. In addition, concepts
         should not be visible if their associated fields are not all available.
+        Also, concepts with an unpublished category are not visible. Finally,
+        concepts with no fields are not considered visible.
         """
         published = super(DataConceptQuerySet, self).published()
 
@@ -74,7 +76,8 @@ class DataConceptQuerySet(PublishedQuerySet):
             fields_q = fields_q | Q(pk__in=restricted_fields)
 
         shadowed = DataField.objects.filter(fields_q)
-        concepts = published.exclude(fields__in=shadowed).distinct()
+        concepts = published.exclude(fields__in=shadowed) \
+            .exclude(fields=None).distinct()
         return concepts
 
 

--- a/tests/cases/models/tests.py
+++ b/tests/cases/models/tests.py
@@ -201,6 +201,11 @@ class DataConceptManagerTestCase(TestCase):
         # `user2` is not assigned
         self.assertEqual([x.pk for x in DataConcept.objects.published(user2)], [])
 
+        # Remove the fields from the concept and it should no longer appear
+        # as published.
+        DataConceptField.objects.filter(concept=concept).delete()
+        self.assertEqual([x.pk for x in DataConcept.objects.published()], [])
+
 
 class DataContextTestCase(TestCase):
     def test_init(self):


### PR DESCRIPTION
This change includes a test to make sure that this is indeed the case. I am of the opinion that publishing a concept with no fields does not make sense so I took the easy route here and removed them from the published set. If anyone thinks we should handle published concepts with no fields in a different manner feel free to comment here but I wanted to either close this or get the conversation started.

Fixes #150.
