### PR TITLE
fixed 'Objectset' typo in avocado.sets.models

### DIFF
--- a/avocado/sets/models.py
+++ b/avocado/sets/models.py
@@ -4,7 +4,7 @@ from avocado.conf import dep_supported, raise_dep_error
 if not dep_supported('objectset'):
     raise_dep_error('objectset')
 
-from objectset.models import Objectset, SetObject  # noqa
+from objectset.models import ObjectSet, SetObject  # noqa
 
 warnings.warn('The built-in ObjectSet and SetObject classes have been '
               'removed in favor of the classes defined in the '


### PR DESCRIPTION
I found this when I tried to test the latest Avocado with the pcgc-varify integration.  However, even when fixed, note that Varify thinks that ObjectSet has a `name` field, which it does not in django-objectset, so this compatibility shim doesn't help with Varify at the moment.  I'm not sure where this latter issue should be raised.
