### PR TITLE
Integrate supplementary fields to base field

### DIFF
--- a/avocado/admin.py
+++ b/avocado/admin.py
@@ -1,8 +1,6 @@
 from django.db import transaction
 from django.contrib import admin
-from django.contrib.admin import SimpleListFilter
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_lazy as _
 from avocado.models import DataField, DataConcept, DataCategory, \
     DataConceptField, DataView, DataContext, DataQuery
 from avocado.forms import DataFieldAdminForm
@@ -53,63 +51,15 @@ class PublishedAdmin(admin.ModelAdmin):
     mark_unarchived.short_description = 'Unarchive'
 
 
-class LexiconListFilter(SimpleListFilter):
-    title = _('lexicon')
-
-    parameter_name = 'lexicon'
-
-    def lookups(self, request, model_admin):
-        return (
-            ('1', _('Yes')),
-            ('0', _('No')),
-        )
-
-    def queryset(self, request, queryset):
-        value = self.value()
-
-        if value:
-            subquery = queryset.only('app_name', 'model_name', 'field_name')
-            ids = [x.pk for x in subquery if x.lexicon]
-            if value == '1':
-                queryset = queryset.filter(id__in=ids)
-            else:
-                queryset = queryset.exclude(id__in=ids)
-            return queryset
-
-
-class ObjectSetListFilter(SimpleListFilter):
-    title = _('objectset')
-
-    parameter_name = 'objectset'
-
-    def lookups(self, request, model_admin):
-        return (
-            ('1', _('Yes')),
-            ('0', _('No')),
-        )
-
-    def queryset(self, request, queryset):
-        value = self.value()
-
-        if value:
-            subquery = queryset.only('app_name', 'model_name', 'field_name')
-            ids = [x.pk for x in subquery if x.objectset]
-            if value == '1':
-                queryset = queryset.filter(id__in=ids)
-            else:
-                queryset = queryset.exclude(id__in=ids)
-            return queryset
-
-
 class DataFieldAdmin(PublishedAdmin):
     form = DataFieldAdminForm
 
     list_display = ('name', 'published', 'archived', 'internal',
                     'orphan_status', 'model_name', 'enumerable',
-                    'is_lexicon', 'is_objectset', 'related_dataconcepts')
+                    'related_dataconcepts')
 
     list_filter = ('published', 'archived', 'internal', 'model_name',
-                   'enumerable', LexiconListFilter, ObjectSetListFilter)
+                   'enumerable')
 
     list_editable = ('published', 'archived', 'internal', 'enumerable')
 
@@ -166,14 +116,6 @@ class DataFieldAdmin(PublishedAdmin):
             return 'Unknown Model Field'
         return 'OK'
     orphan_status.short_description = 'Orphan Status'
-
-    def is_lexicon(self, obj):
-        return obj.lexicon
-    is_lexicon.short_description = 'Is Lexicon'
-
-    def is_objectset(self, obj):
-        return obj.objectset
-    is_objectset.short_description = 'Is ObjectSet'
 
     def related_dataconcepts(self, obj):
         queryset = obj.concepts.only('id', 'name')

--- a/avocado/export/_r.py
+++ b/avocado/export/_r.py
@@ -67,7 +67,7 @@ class RExporter(BaseExporter):
                 labels.append(u'attr(data${0}, "label") = "{1}"'.format(
                     name, unicode(cfield)))
 
-                if field.lexicon:
+                if field.code_field:
                     codes = self._code_values(name, field)
                     factors.append(codes[0])
                     levels.append(codes[1])

--- a/avocado/export/_sas.py
+++ b/avocado/export/_sas.py
@@ -109,7 +109,7 @@ class SASExporter(BaseExporter):
 
                 # If a field can be coded create a SAS PROC Format statement
                 # that creates a value dictionary
-                if field.lexicon:
+                if field.code_field:
                     value_format, value = self._code_values(name, field)
                     value_formats.append(value_format)
                     values.append(value)

--- a/avocado/management/subcommands/init.py
+++ b/avocado/management/subcommands/init.py
@@ -128,6 +128,7 @@ class Command(BaseCommand):
 
             for model in pending_models:
                 lexicon = issubclass(model, Lexicon)
+
                 if dep_supported('objectset'):
                     from objectset.models import ObjectSet
                     objectset = issubclass(model, ObjectSet)
@@ -183,9 +184,11 @@ class Command(BaseCommand):
         else:
             objectset = False
 
+        lexicon = issubclass(field.model, Lexicon)
+
         # Lexicons and ObjectSets are represented via their primary key, so
         # these may pass
-        if not objectset and not issubclass(field.model, Lexicon):
+        if not objectset and not lexicon:
             # Check for primary key, and foreign key fields
             if isinstance(field, self.key_field_types) and not include_keys:
                 print(u'({0}) {1}.{2} is a primary or foreign key. Skipping...'
@@ -214,6 +217,17 @@ class Command(BaseCommand):
             'model_name': model_name.lower(),
             'field_name': field.name,
         }
+
+        if lexicon:
+            kwargs.update({
+                'label_field_name': 'label',
+                'order_field_name': 'order',
+                'code_field_name': 'code',
+            })
+        elif objectset and hasattr(field.model, 'label_field'):
+            kwargs.update({
+                'label_field_name': field.model.label_field
+            })
 
         try:
             f = DataField.objects.get(**lookup)

--- a/avocado/migrations/0032_auto__add_field_datafield_label_field_name__add_field_datafield_search.py
+++ b/avocado/migrations/0032_auto__add_field_datafield_label_field_name__add_field_datafield_search.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'DataField.label_field_name'
+        db.add_column(u'avocado_datafield', 'label_field_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=200, null=True),
+                      keep_default=False)
+
+        # Adding field 'DataField.search_field_name'
+        db.add_column(u'avocado_datafield', 'search_field_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=200, null=True),
+                      keep_default=False)
+
+        # Adding field 'DataField.order_field_name'
+        db.add_column(u'avocado_datafield', 'order_field_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=200, null=True),
+                      keep_default=False)
+
+        # Adding field 'DataField.code_field_name'
+        db.add_column(u'avocado_datafield', 'code_field_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=200, null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'DataField.label_field_name'
+        db.delete_column(u'avocado_datafield', 'label_field_name')
+
+        # Deleting field 'DataField.search_field_name'
+        db.delete_column(u'avocado_datafield', 'search_field_name')
+
+        # Deleting field 'DataField.order_field_name'
+        db.delete_column(u'avocado_datafield', 'order_field_name')
+
+        # Deleting field 'DataField.code_field_name'
+        db.delete_column(u'avocado_datafield', 'code_field_name')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'avocado.datacategory': {
+            'Meta': {'ordering': "('parent__order', 'parent__name', 'order', 'name')", 'object_name': 'DataCategory'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.FloatField', [], {'null': 'True', 'db_column': "'_order'", 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['avocado.DataCategory']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'avocado.dataconcept': {
+            'Meta': {'ordering': "('category__order', 'category__name', 'order', 'name')", 'object_name': 'DataConcept'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['avocado.DataCategory']", 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'fields': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'concepts'", 'symmetrical': 'False', 'through': u"orm['avocado.DataConceptField']", 'to': u"orm['avocado.DataField']"}),
+            'formatter_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'concepts+'", 'null': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'internal': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'name_plural': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.FloatField', [], {'null': 'True', 'db_column': "'_order'", 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'concepts+'", 'blank': 'True', 'to': u"orm['sites.Site']"}),
+            'sortable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'viewable': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'avocado.dataconceptfield': {
+            'Meta': {'ordering': "('order', 'name')", 'object_name': 'DataConceptField'},
+            'concept': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'concept_fields'", 'to': "orm['avocado.DataConcept']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'field': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'concept_fields'", 'to': u"orm['avocado.DataField']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name_plural': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.FloatField', [], {'null': 'True', 'db_column': "'_order'", 'blank': 'True'})
+        },
+        u'avocado.datacontext': {
+            'Meta': {'object_name': 'DataContext'},
+            'accessed': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 2, 25, 0, 0)'}),
+            'count': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_column': "'_count'"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'json': ('jsonfield.fields.JSONField', [], {'default': '{}', 'null': 'True', 'blank': 'True'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'forks'", 'null': 'True', 'to': u"orm['avocado.DataContext']"}),
+            'session': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'session_key': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'template': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'tree': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'datacontext+'", 'null': 'True', 'to': u"orm['auth.User']"})
+        },
+        u'avocado.datafield': {
+            'Meta': {'ordering': "('category__order', 'category__name', 'order', 'name')", 'unique_together': "(('app_name', 'model_name', 'field_name'),)", 'object_name': 'DataField'},
+            'app_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['avocado.DataCategory']", 'null': 'True', 'blank': 'True'}),
+            'code_field_name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'enumerable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'fields+'", 'null': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'label_field_name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'name_plural': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.FloatField', [], {'null': 'True', 'db_column': "'_order'", 'blank': 'True'}),
+            'order_field_name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'search_field_name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'fields+'", 'blank': 'True', 'to': u"orm['sites.Site']"}),
+            'translator': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'unit': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'unit_plural': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'})
+        },
+        u'avocado.dataquery': {
+            'Meta': {'object_name': 'DataQuery'},
+            'accessed': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'context_json': ('jsonfield.fields.JSONField', [], {'default': '{}', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'distinct_count': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'forks'", 'null': 'True', 'to': u"orm['avocado.DataQuery']"}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'record_count': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'session': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'session_key': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'shared_users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'shareddataquery+'", 'symmetrical': 'False', 'to': u"orm['auth.User']"}),
+            'template': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'tree': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dataquery+'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'view_json': ('jsonfield.fields.JSONField', [], {'default': '{}', 'null': 'True', 'blank': 'True'})
+        },
+        u'avocado.dataview': {
+            'Meta': {'object_name': 'DataView'},
+            'accessed': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 2, 25, 0, 0)'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'json': ('jsonfield.fields.JSONField', [], {'default': '{}', 'null': 'True', 'blank': 'True'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'forks'", 'null': 'True', 'to': u"orm['avocado.DataView']"}),
+            'session': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'session_key': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'template': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dataview+'", 'null': 'True', 'to': u"orm['auth.User']"})
+        },
+        'avocado.log': {
+            'Meta': {'object_name': 'Log'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'data': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'event': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'session_key': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': u"orm['auth.User']"})
+        },
+        'avocado.revision': {
+            'Meta': {'ordering': "('-timestamp',)", 'object_name': 'Revision'},
+            'changes': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'data': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'session_key': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+revision'", 'null': 'True', 'to': u"orm['auth.User']"})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['avocado']

--- a/tests/cases/lexicon/tests.py
+++ b/tests/cases/lexicon/tests.py
@@ -8,7 +8,6 @@ class LexiconTestCase(TestCase):
 
     def test_datafield(self):
         f = DataField(app_name='tests', model_name='month', field_name='id')
-        self.assertTrue(f.lexicon)
         self.assertEqual(f.values(), (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
         self.assertEqual(f.labels(), (u'January', u'February', u'March',
             u'April', u'May', u'June', u'July', u'August', u'September',
@@ -17,7 +16,6 @@ class LexiconTestCase(TestCase):
 
     def test_foreign_key_datafield(self):
         f = DataField(app_name='tests', model_name='date', field_name='month')
-        self.assertTrue(f.lexicon)
         self.assertEqual(f.model, Month)
         self.assertEqual(f.field, Month._meta.pk)
         self.assertEqual(f.values(), (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))


### PR DESCRIPTION
This adds support for defining an explicit label, search, code,
and order field that exists on the same model of the base field. This
provides a more dynamic nature to a data field by having it be represented
in various ways depending on how it is being interacted with.

This implementation supersedes the need for direct integration of the
Lexicon and ObjectSet classes in the DataField API. Detection of these
types will be removed in 2.4, however the detection during the avocado
init will remain for now.
