### PR TITLE
Allow user to share by username

### DIFF
--- a/avocado/conf/global_settings.py
+++ b/avocado/conf/global_settings.py
@@ -99,3 +99,11 @@ VALIDATION_WARNINGS = {}
 # Toggle whether DataField instances should cache the underlying data
 # for their most common data access methods.
 DATA_CACHE_ENABLED = True
+
+# These settings affect how queries can be shared between users.
+# A user is able to enter either a username or an email of another user
+# they wish to share the query with. To limit to only one type of sharing
+# set the appropriate setting to True and all others to false.
+SHARE_BY_USERNAME = True
+SHARE_BY_EMAIL = True
+SHARE_BY_USERNAME_CASE_SENSITIVE = True


### PR DESCRIPTION
Fix #192 
Changed models and test cases to allow for sharing with username lookup. The client should specify the settings in the settings file. Otherwise, `SHARE_BY_USERNAME = True` and `SHARE_BY_EMAIL=True` by default.
Signed-off-by: Sheik Hassan solergiga@yahoo.com
