### PR TITLE
Remove system_site_packages flag in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
     - DJANGO=1.4.10
     - DJANGO=1.5.5
 
-virtualenv:
-    system_site_packages: true
-
 services:
     - memcache
 


### PR DESCRIPTION
Fixes issue where all builds for python 2.6 were failing. More details can be found [here](https://github.com/travis-ci/travis-ci/issues/2219).

Signed-off-by: Don Naegely naegelyd@gmail.com
