### PR TITLE
Add optional queryset approach on data-dependent methods

### DIFF
--- a/avocado/stats/agg.py
+++ b/avocado/stats/agg.py
@@ -7,7 +7,7 @@ from modeltree.utils import M
 
 
 class Aggregator(object):
-    def __init__(self, field, model=None):
+    def __init__(self, field, queryset=None, model=None):
         if not isinstance(field, models.Field):
             if not model:
                 raise TypeError('Field instance or field name and model class '
@@ -21,8 +21,8 @@ class Aggregator(object):
         self.field = field
         self.field_name = field_name
         self.model = model
+        self._queryset = queryset
 
-        self._queryset = None
         self._aggregates = {}
         self._filter = []
         self._exclude = []
@@ -104,14 +104,13 @@ class Aggregator(object):
         return queryset
 
     def _clone(self):
-        clone = self.__class__(self.field_name, self.model)
+        clone = self.__class__(self.field_name, self._queryset, self.model)
         clone._aggregates = deepcopy(self._aggregates)
         clone._filter = deepcopy(self._filter)
         clone._exclude = deepcopy(self._exclude)
         clone._having = deepcopy(self._having)
         clone._groupby = deepcopy(self._groupby)
         clone._orderby = deepcopy(self._orderby)
-        clone._queryset = self._queryset
         return clone
 
     def _aggregate(self, *groupby, **aggregates):

--- a/tests/cases/stats/tests/agg.py
+++ b/tests/cases/stats/tests/agg.py
@@ -24,6 +24,10 @@ class AggregatorTestCase(TestCase):
         self.assertEqual(self.salary.count(), [{'count': 7}])
         self.assertEqual(self.first_name.count(), [{'count': 6}])
 
+        queryset = self.is_manager.model.objects.filter(is_manager=True)
+        self.assertEqual(
+            self.is_manager.count(queryset=queryset), [{'count': 1}])
+
     @override_settings(AVOCADO_DATA_CACHE_ENABLED=True)
     def test_count_cached(self):
         self.is_manager.count.flush(self.is_manager)
@@ -39,6 +43,9 @@ class AggregatorTestCase(TestCase):
         self.assertEqual(self.is_manager.max(), [{'max': 1}])
         self.assertEqual(self.salary.max(), [{'max': 200000}])
         self.assertEqual(self.first_name.max(), [{'max': 'Zac'}])
+
+        queryset = self.salary.model.objects.filter(salary__lt=200000)
+        self.assertEqual(self.salary.max(queryset=queryset), [{'max': 100000}])
 
     @override_settings(AVOCADO_DATA_CACHE_ENABLED=True)
     def test_max_cached(self):
@@ -56,6 +63,9 @@ class AggregatorTestCase(TestCase):
         self.assertEqual(self.salary.min(), [{'min': 10000}])
         self.assertEqual(self.first_name.min(), [{'min': 'Aaron'}])
 
+        queryset = self.salary.model.objects.filter(salary__gt=100000)
+        self.assertEqual(self.salary.min(queryset=queryset), [{'min': 200000}])
+
     @override_settings(AVOCADO_DATA_CACHE_ENABLED=True)
     def test_min_cached(self):
         self.is_manager.min.flush(self.is_manager)
@@ -72,6 +82,9 @@ class AggregatorTestCase(TestCase):
         self.assertEqual(self.salary.avg(), [{'avg': 53571.42857142857}])
         self.assertEqual(self.first_name.avg(), None)
 
+        queryset = self.salary.model.objects.filter(salary__gte=100000)
+        self.assertEqual(self.salary.avg(queryset=queryset), [{'avg': 150000}])
+
     @override_settings(AVOCADO_DATA_CACHE_ENABLED=True)
     def test_avg_cached(self):
         self.salary.avg.flush(self.salary)
@@ -87,6 +100,9 @@ class AggregatorTestCase(TestCase):
         self.assertEqual(self.is_manager.sum(), None)
         self.assertEqual(self.salary.sum(), [{'sum': 375000}])
         self.assertEqual(self.first_name.sum(), None)
+
+        queryset = self.salary.model.objects.filter(salary__gte=100000)
+        self.assertEqual(self.salary.sum(queryset=queryset), [{'sum': 300000}])
 
     @override_settings(AVOCADO_DATA_CACHE_ENABLED=True)
     def test_sum_cached(self):
@@ -107,6 +123,10 @@ class AggregatorTestCase(TestCase):
             self.assertEqual(self.is_manager.stddev(), None)
             self.assertEqual(self.salary.stddev(), [{'stddev': 66639.4502268}])
             self.assertEqual(self.first_name.stddev(), None)
+
+            queryset = self.salary.model.objects.filter(salary__lt=20000)
+            self.assertEqual(
+                self.salary.stddev(queryset=queryset), [{'stddev': 2500}])
     else:
         def test_stddev(self):
             self.assertRaises(DatabaseError, self.is_manager.stddev())
@@ -121,6 +141,11 @@ class AggregatorTestCase(TestCase):
                 'variance': 4440816326.530612
             }])
             self.assertEqual(self.first_name.variance(), None)
+
+            queryset = self.salary.model.objects.filter(salary__lt=20000)
+            self.assertEqual(self.salary.variance(queryset=queryset), [{
+                'variance': 6250000
+            }])
     else:
         def test_variance(self):
             self.assertRaises(DatabaseError, self.is_manager.variance())


### PR DESCRIPTION
Fix #219. Instead of having each method take a processor as was outlined in the original ticket, I have them take an optional queryset argument. This is much more generic than a processor or processor name but can still be used in the case of a custom processor by supplying these methods with the returned value of the `get_queryset(...)` method on the processor.

Signed-off-by: Don Naegely naegelyd@gmail.com
