### PR TITLE
Change migrate to use native DataField API

### DIFF
--- a/avocado/migrations/0036_initialize_indexable.py
+++ b/avocado/migrations/0036_initialize_indexable.py
@@ -3,11 +3,12 @@ from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration
 from django.db import models
+from avocado.models import DataField
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        for field in orm.DataField.objects.all():
+        for field in DataField.objects.all():
             field.indexable = field.enumerable or field.searchable
             field.save()
 


### PR DESCRIPTION
The recommendation for schema migrations are to use the South
`orm` proxy. Data migrations are generally less problematic in
this regard, so the native model is used here to have access
to properties and methods (such as `searchable`).

Fix #227

Signed-off-by: Byron Ruth b@devel.io
