### PR TITLE
Add custom pickling support for Aggregator class

### DIFF
--- a/avocado/core/cache/model.py
+++ b/avocado/core/cache/model.py
@@ -25,11 +25,14 @@ def _prep_pickling(args, kwargs):
     else:
         args = None
 
+    _kwargs = {}
+
     if kwargs:
-        kwargs = dict([
-            (k, _pickling_value(v))
-            for k, v in kwargs.items()
-        ])
+        for k, v in kwargs.items():
+            if v is not None:
+                _kwargs[k] = _pickling_value(v)
+
+        kwargs = _kwargs or None
     else:
         kwargs = None
 


### PR DESCRIPTION
This ensures the internal queryset does not get evaluated when the
aggregator instance is pickled.

Fix #235

Signed-off-by: Byron Ruth b@devel.io
