### PR TITLE
Replace hard reference to value_field_name

### DIFF
--- a/avocado/models.py
+++ b/avocado/models.py
@@ -642,7 +642,7 @@ class DataField(BasePlural, PublishArchiveMixin):
         if count == 0:
             return 1.0
 
-        isnull = '{0}__isnull'.format(self.value_field_name)
+        isnull = '{0}__isnull'.format(self.value_field.name)
         nulls = queryset.filter(**{isnull: True}).count()
 
         return nulls / float(count)
@@ -652,9 +652,9 @@ class DataField(BasePlural, PublishArchiveMixin):
         if queryset is None:
             queryset = self.model.objects.all()
 
-        queryset = queryset.annotate(cnt=Count(self.value_field_name))\
-            .values_list(self.value_field_name, 'cnt')\
-            .order_by(self.value_field_name)
+        queryset = queryset.annotate(cnt=Count(self.value_field.name))\
+            .values_list(self.value_field.name, 'cnt')\
+            .order_by(self.value_field.name)
 
         return tuple(queryset)
 

--- a/tests/cases/lexicon/tests.py
+++ b/tests/cases/lexicon/tests.py
@@ -46,3 +46,9 @@ class LexiconTestCase(TestCase):
             'SELECT "tests_month"."id" FROM "tests_month" WHERE '
             '"tests_month"."label" LIKE J% ESCAPE \'\\\'  ORDER BY '
             '"tests_month"."order" ASC')
+
+    def test_dist(self):
+        f = DataField(app_name='tests', model_name='date', field_name='month')
+        # Months of the year
+        result = tuple([(i, 1) for i in range(1, 13)])
+        self.assertEqual(f.dist(), result)


### PR DESCRIPTION
The `value_field` property returns the field relative to the model
which, in the case of a Lexicon, is the primary key, not the local
foreign key field.

Fix #238

Signed-off-by: Byron Ruth b@devel.io
