### PR TITLE
Refactor formatter for model-derived typing

### DIFF
--- a/avocado/export/_base.py
+++ b/avocado/export/_base.py
@@ -7,7 +7,7 @@ class BaseExporter(object):
     "Base class for all exporters"
     file_extension = 'txt'
     content_type = 'text/plain'
-    preferred_formats = []
+    preferred_formats = ()
 
     def __init__(self, concepts=None):
         if concepts is None:

--- a/avocado/export/_csv.py
+++ b/avocado/export/_csv.py
@@ -30,7 +30,7 @@ class CSVExporter(BaseExporter):
     file_extension = 'csv'
     content_type = 'text/csv'
 
-    preferred_formats = ('csv', 'number', 'string')
+    preferred_formats = ('csv', 'string')
 
     def write(self, iterable, buff=None, *args, **kwargs):
         header = []
@@ -39,11 +39,16 @@ class CSVExporter(BaseExporter):
 
         for i, row_gen in enumerate(self.read(iterable, *args, **kwargs)):
             row = []
+
             for data in row_gen:
                 if i == 0:
                     header.extend(data.keys())
+
                 row.extend(data.values())
+
             if i == 0:
                 writer.writerow(header)
+
             writer.writerow(row)
+
         return buff

--- a/avocado/export/_excel.py
+++ b/avocado/export/_excel.py
@@ -16,7 +16,7 @@ class ExcelExporter(BaseExporter):
     file_extension = 'xlsx'
     content_type = 'application/vnd.ms-excel'
 
-    preferred_formats = ('excel', 'boolean', 'number', 'string')
+    preferred_formats = ('excel', 'string')
 
     def write(self, iterable, buff=None, *args, **kwargs):
         buff = self.get_file_obj(buff)
@@ -27,33 +27,49 @@ class ExcelExporter(BaseExporter):
         ws_data.title = 'Data'
 
         header = []
+
         # Create the data worksheet
         for i, row_gen in enumerate(self.read(iterable, *args, **kwargs)):
             row = []
+
             for data in row_gen:
                 if i == 0:
                     # Build up header row
                     header.extend(data.keys())
+
                 # Add formatted section to the row
                 row.extend(data.values())
+
             # Write headers on first iteration
             if i == 0:
                 ws_data.append(header)
+
             ws_data.append(row)
 
         ws_dict = wb.create_sheet()
         ws_dict.title = 'Data Dictionary'
 
         # Create the Data Dictionary Worksheet
-        ws_dict.append(('Field Name', 'Data Type', 'Description',
-                        'Concept Name', 'Concept Discription'))
+        ws_dict.append((
+            'Field Name',
+            'Data Type',
+            'Description',
+            'Concept Name',
+            'Concept Description',
+        ))
 
         for c in self.concepts:
             cfields = c.concept_fields.select_related('field')
+
             for cfield in cfields:
                 field = cfield.field
-                ws_dict.append((field.field_name, field.simple_type,
-                                field.description, c.name, c.description))
+                ws_dict.append((
+                    field.field_name,
+                    field.simple_type,
+                    field.description,
+                    c.name,
+                    c.description,
+                ))
 
         # This hacked up implementation is due to `save_virtual_workbook`
         # not behaving correctly. This function should handle the work
@@ -66,4 +82,5 @@ class ExcelExporter(BaseExporter):
             _buff.close()
         else:
             wb.save(buff)
+
         return buff

--- a/avocado/export/_html.py
+++ b/avocado/export/_html.py
@@ -20,4 +20,5 @@ class HTMLExporter(BaseExporter):
 
         context = Context({'rows': self.read(iterable, *args, **kwargs)})
         buff.write(template.render(context))
+
         return buff

--- a/avocado/export/_json.py
+++ b/avocado/export/_json.py
@@ -18,12 +18,14 @@ class JSONExporter(BaseExporter):
     file_extension = 'json'
     content_type = 'application/json'
 
-    preferred_formats = ('json', 'number', 'string')
+    preferred_formats = ('json',)
 
     def write(self, iterable, buff=None, *args, **kwargs):
         buff = self.get_file_obj(buff)
 
         encoder = JSONGeneratorEncoder()
+
         for chunk in encoder.iterencode(self.read(iterable, *args, **kwargs)):
             buff.write(chunk)
+
         return buff

--- a/avocado/export/_r.py
+++ b/avocado/export/_r.py
@@ -14,18 +14,21 @@ class RExporter(BaseExporter):
     file_extension = 'zip'
     content_type = 'application/zip'
 
-    preferred_formats = ('r', 'coded', 'number', 'string')
+    preferred_formats = ('r', 'coded')
 
     def _format_name(self, name):
         punc = punctuation.replace('_', '')
         name = str(name).translate(None, punc)
         name = name.replace(' ', '_')
         words = name.split('_')
+
         for i, w in enumerate(words):
             if i == 0:
                 name = w.lower()
                 continue
+
             name += w.capitalize()
+
         if name[0].isdigit():
             name = '_' + name
 
@@ -56,6 +59,7 @@ class RExporter(BaseExporter):
 
     def write(self, iterable, buff=None, template_name='export/script.R',
               *args, **kwargs):
+
         zip_file = ZipFile(self.get_file_obj(buff), 'w')
 
         factors = []      # field names
@@ -68,8 +72,8 @@ class RExporter(BaseExporter):
             for cfield in cfields:
                 field = cfield.field
                 name = self._format_name(field.field_name)
-                labels.append(u'attr(data${0}, "label") = "{1}"'.format(
-                    name, unicode(cfield)))
+                labels.append(u'attr(data${0}, "label") = "{1}"'
+                              .format(name, unicode(cfield)))
 
                 coded_labels = field.coded_labels()
 

--- a/avocado/export/_sas.py
+++ b/avocado/export/_sas.py
@@ -14,7 +14,7 @@ class SASExporter(BaseExporter):
     file_extension = 'zip'
     content_type = 'application/zip'
 
-    preferred_formats = ('sas', 'coded', 'number', 'string')
+    preferred_formats = ('sas', 'coded')
 
     num_lg_names = 0
 

--- a/tests/cases/formatters/tests.py
+++ b/tests/cases/formatters/tests.py
@@ -33,6 +33,14 @@ class FormatterTestCase(TestCase):
         self.values = ['CEO', 100000, True]
         self.f = Formatter(concept)
 
+    def test_default(self):
+        fvalues = self.f(self.values)
+        self.assertEqual(OrderedDict([
+            ('name', 'CEO'),
+            ('salary', 100000),
+            ('boss', True),
+        ]), fvalues)
+
     def test_to_string(self):
         fvalues = self.f(self.values, preferred_formats=['string'])
         self.assertEqual(OrderedDict([


### PR DESCRIPTION
This improves formatter processing to consider the `DataConcept` and
`DataField` `type` fields introduced in 878a3139 and cddcd9b,
respectively. In addition, the `DataField`'s simple type is included as
a fallback prior to using the 'raw' format.

This removes the need for `Formatter.default_formats` and reduces the
number of the `preferred_formats` across the exporter classes.

Fix #242

Signed-off-by: Byron Ruth b@devel.io
