### PR TITLE
Add PERMISSIONS_ENABLED setting

### DIFF
--- a/avocado/conf/global_settings.py
+++ b/avocado/conf/global_settings.py
@@ -107,3 +107,9 @@ DATA_CACHE_ENABLED = True
 SHARE_BY_USERNAME = True
 SHARE_BY_EMAIL = True
 SHARE_BY_USERNAME_CASE_SENSITIVE = True
+
+# Toggle whether the permissions system should be enabled.
+# If django-guardian is installed and this value is None or True, permissions
+# will be applied. If the value is True and django-guardian is not installed
+# it is an error. If set to False the permissions will not be applied.
+PERMISSIONS_ENABLED = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Django>=1.4,<1.6
-South==0.8.1
+South>=0.8.1
 Whoosh==2.4.1
-django-guardian==1.0.4
+django-guardian>=1.0.4
 django-haystack==2.0.0
 django-objectset>=0.2.2
-jsonfield==0.9.4
+jsonfield>=0.9.4
 modeltree>=1.1.8
 openpyxl>=1.6,<1.7
 python-memcached>=1.48


### PR DESCRIPTION
This fixes an ambiguity when applying the permissions if a user is
passed to the published() manager method for DataField and DataConcept.

Fix #252

Signed-off-by: Byron Ruth b@devel.io
