### PR TITLE
Implement general purpose cache_key function

### DIFF
--- a/avocado/core/cache/__init__.py
+++ b/avocado/core/cache/__init__.py
@@ -1,4 +1,4 @@
-from .model import instance_cache_key, cached_method  # noqa
+from .model import cache_key, instance_cache_key, cached_method  # noqa
 from .receivers import post_save_cache, pre_delete_uncache  # noqa
 from .managers import CacheManager  # noqa
 from .query import CacheQuerySet  # noqa


### PR DESCRIPTION
This includes the non-instance logic from instance_cache_key. In addition
a warning is emitted for types that do not implement the **getstate** method
for pickling.

Fix #258

Signed-off-by: Byron Ruth b@devel.io
