### PR TITLE
Add settings for declaring explicit caches

### DIFF
--- a/avocado/conf/global_settings.py
+++ b/avocado/conf/global_settings.py
@@ -113,3 +113,10 @@ SHARE_BY_USERNAME_CASE_SENSITIVE = True
 # will be applied. If the value is True and django-guardian is not installed
 # it is an error. If set to False the permissions will not be applied.
 PERMISSIONS_ENABLED = None
+
+# Caches are used to improve performance across various APIs. The two primary
+# ones are data and query. Data cache is used for individual data field
+# caching such as counts, values, and aggregations. Query cache is used for
+# the ad-hoc queries built from a context and view.
+DATA_CACHE = 'default'
+QUERY_CACHE = 'default'

--- a/avocado/core/cache/proxy.py
+++ b/avocado/core/cache/proxy.py
@@ -1,5 +1,6 @@
 import logging
-from django.core.cache import cache
+from django.core.cache import get_cache
+from avocado.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ class CacheProxy(object):
 
     def _set(self, key, data):
         logger.debug('Compute property cache "{0}"'.format(key))
+        cache = get_cache(settings.DATA_CACHE)
 
         if data is not None:
             cache.set(key, data, timeout=self.timeout)
@@ -25,6 +27,7 @@ class CacheProxy(object):
 
     def get(self, instance, args=None, kwargs=None):
         key = self.cache_key(instance, args, kwargs)
+        cache = get_cache(settings.DATA_CACHE)
         data = cache.get(key)
         logger.debug('Get property cache "{0}"'.format(key))
         return data
@@ -33,6 +36,7 @@ class CacheProxy(object):
         # Reference to prevent the key from being changed mid-execution
         key = self.cache_key(instance, args, kwargs)
 
+        cache = get_cache(settings.DATA_CACHE)
         data = cache.get(key)
 
         if data is None:
@@ -50,9 +54,11 @@ class CacheProxy(object):
     def flush(self, instance, args=None, kwargs=None):
         "Flushes cached data for this method."
         key = self.cache_key(instance, args, kwargs)
+        cache = get_cache(settings.DATA_CACHE)
         cache.delete(key)
         logger.debug('Delete property cache "{0}"'.format(key))
 
     def cached(self, instance, args=None, kwargs=None):
         "Checks if the data is in the cache."
+        cache = get_cache(settings.DATA_CACHE)
         return self.cache_key(instance, args, kwargs) in cache

--- a/avocado/core/cache/query.py
+++ b/avocado/core/cache/query.py
@@ -1,5 +1,6 @@
-from django.core.cache import cache
+from django.core.cache import get_cache
 from django.db.models.query import QuerySet
+from avocado.conf import settings
 from .model import cache_key_func
 
 PK_LOOKUPS = ('pk', 'pk__exact')
@@ -25,6 +26,7 @@ class CacheQuerySet(QuerySet):
 
         if pk is not None:
             key = cache_key_func([opts.app_label, opts.module_name, pk])
+            cache = get_cache(settings.DATA_CACHE)
             obj = cache.get(key)
 
             if obj is not None:

--- a/avocado/core/cache/receivers.py
+++ b/avocado/core/cache/receivers.py
@@ -1,4 +1,5 @@
-from django.core.cache import cache
+from django.core.cache import get_cache
+from avocado.conf import settings
 from .model import instance_cache_key, NEVER_EXPIRE
 
 
@@ -7,9 +8,11 @@ def post_save_cache(sender, instance, **kwargs):
     be used in conjunction with the `pre_delete_uncache` since the cache is set
     to never expire.
     """
+    cache = get_cache(settings.DATA_CACHE)
     cache.set(instance_cache_key(instance), instance, timeout=NEVER_EXPIRE)
 
 
 def pre_delete_uncache(sender, instance, **kwargs):
     "General post-delete handler for removing cache for model instances."
+    cache = get_cache(settings.DATA_CACHE)
     cache.delete(instance_cache_key(instance))


### PR DESCRIPTION
This introduces the DATA_CACHE and QUERY_CACHE settings to enable
separating where the data-centric and query-centric cache live.

The two motivations for this distinction is control over the
individual caches and freedom of choosing a more appropriate cache
for data vs. query results.

Fix #297

Signed-off-by: Byron Ruth <b@devel.io>