### PR TITLE
Refactor formatter to reduce overhead

### DIFF
--- a/avocado/export/_base.py
+++ b/avocado/export/_base.py
@@ -1,15 +1,21 @@
-from avocado.models import DataConcept, DataView
-from avocado.formatters import Formatter
+import functools
+from multiprocessing.pool import ThreadPool
+from avocado.models import DataView
+from avocado.formatters import registry as formatters
 from cStringIO import StringIO
 
 
 class BaseExporter(object):
     "Base class for all exporters"
+    short_name = 'base'
     file_extension = 'txt'
     content_type = 'text/plain'
     preferred_formats = ()
 
-    def __init__(self, concepts=None):
+    def __init__(self, concepts=None, preferred_formats=None):
+        if preferred_formats is not None:
+            self.preferred_formats = preferred_formats
+
         if concepts is None:
             concepts = ()
         elif isinstance(concepts, DataView):
@@ -20,22 +26,27 @@ class BaseExporter(object):
         self.row_length = 0
         self.concepts = concepts
 
+        self._header = []
+
         for concept in concepts:
-            self.add_formatter(concept)
+            formatter_class = formatters.get(concept.formatter)
+            self.add_formatter(formatter_class, concept=concept)
+
+        self._format_cache = {}
 
     def __repr__(self):
         return u'<{0}: {1}/{2}>'.format(self.__class__.__name__,
                                         len(self.params), self.row_length)
 
-    def add_formatter(self, formatter, length=None, index=None):
-        if isinstance(formatter, DataConcept):
-            length = formatter.concept_fields.count()
-            formatter = formatter.format
-        elif isinstance(formatter, Formatter):
-            length = len(formatter.keys)
-        elif length is None:
-            raise ValueError('A length must be supplied with the to '
-                             'denote how much of the row will be formatted.')
+    def add_formatter(self, formatter_class, concept=None, keys=None,
+                      index=None):
+
+        # Initialize a formatter instance.
+        formatter = formatter_class(concept=concept,
+                                    keys=keys,
+                                    formats=self.preferred_formats)
+
+        length = len(formatter.field_names)
 
         params = (formatter, length)
         self.row_length += length
@@ -45,22 +56,116 @@ class BaseExporter(object):
         else:
             self.params.append(params)
 
+        # Get the expected fields from this formatter to build
+        # up the header.
+        meta = formatter.get_meta(exporter=self.short_name.lower())
+        header = meta['header']
+
+        if index is not None:
+            self._header = (self._header[:index] +
+                            list(header) +
+                            self._header[index:])
+        else:
+            self._header.extend(header)
+
+    @property
+    def header(self):
+        return tuple(self._header)
+
     def get_file_obj(self, name=None):
         if name is None:
             return StringIO()
+
         if isinstance(name, basestring):
             return open(name, 'w+')
+
         return name
 
-    def _format_row(self, row, **kwargs):
+    def _format_row(self, row, kwargs=None):
+        _row = []
+
         for formatter, length in self.params:
             values, row = row[:length], row[length:]
-            yield formatter(values, preferred_formats=self.preferred_formats,
-                            **kwargs)
 
-    def read(self, iterable, force_distinct=True, offset=None, limit=None,
-             *args, **kwargs):
-        """Takes an iterable that produces rows to be formatted.
+            _row.extend(formatter(values, kwargs=kwargs))
+
+        return tuple(_row)
+
+    def _cache_format_row(self, row, kwargs=None):
+        _row = []
+
+        for formatter, length in self.params:
+            values, row = row[:length], row[length:]
+
+            key = (formatter, values)
+
+            if key not in self._format_cache:
+                segment = formatter(values, kwargs=kwargs)
+
+                self._format_cache[key] = segment
+            else:
+                segment = self._format_cache[key]
+
+            _row.extend(segment)
+
+        return tuple(_row)
+
+    def read(self, iterable, *args, **kwargs):
+        "Reads an iterable and generates formatted rows."
+        for row in iterable:
+            yield self._format_row(row, kwargs=kwargs)
+
+    def cached_read(self, iterable, *args, **kwargs):
+        """Reads an iterable and generates formatted rows.
+
+        This read implementation caches the output segments of the input
+        values and can significantly speed up formatting at the expense of
+        memory.
+
+        The benefit of this method is dependent on the data. If there is
+        high variability in the data, this method may not perform well.
+        """
+        self._format_cache = {}
+
+        for row in iterable:
+            yield self._cache_format_row(row, kwargs=kwargs)
+
+    def threaded_read(self, iterable, threads=None, *args, **kwargs):
+        """Reads an iterable and generates formatted rows.
+
+        This read implementation starts a pool of worker threads to format
+        the data in parallel.
+        """
+        pool = ThreadPool(threads)
+
+        f = functools.partial(self._format_row,
+                              kwargs=kwargs)
+
+        for row in pool.map(f, iterable):
+            yield row
+
+    def cached_threaded_read(self, iterable, threads=None, *args, **kwargs):
+        """Reads an iterable and generates formatted rows.
+
+        This read implementation combines the `cached_read` and `threaded_read`
+        methods.
+        """
+        self._format_cache = {}
+
+        pool = ThreadPool(threads)
+
+        f = functools.partial(self._cache_format_row,
+                              kwargs=kwargs)
+
+        for row in pool.map(f, iterable):
+            yield row
+
+    def manual_read(self, iterable, force_distinct=True, offset=None,
+                    limit=None, *args, **kwargs):
+        """Reads an iterable and generates formatted rows.
+
+        This method must be used if columns were added to the query to get
+        particular ordering, but are not part of the concepts being handled.
 
         If `force_distinct` is true, rows will be filtered based on the slice
         of the row that is going to be formatted.
@@ -90,11 +195,9 @@ class BaseExporter(object):
 
             if offset is None or i >= offset:
                 emitted += 1
-                yield self._format_row(_row, **kwargs)
+
+                yield self._format_row(_row, kwargs=kwargs)
 
     def write(self, iterable, *args, **kwargs):
-        for row_gen in self.read(iterable, *args, **kwargs):
-            row = []
-            for data in row_gen:
-                row.extend(data.values())
-            yield tuple(row)
+        for row in iterable:
+            yield row

--- a/avocado/export/_csv.py
+++ b/avocado/export/_csv.py
@@ -15,8 +15,11 @@ class UnicodeWriter(object):
         self.writer = csv.writer(f, dialect, *args, **kwds)
 
     def writerow(self, row):
-        self.writer.writerow(
-            [s.encode("utf-8") if 'encode' in dir(s) else s for s in row])
+        self.writer.writerow([
+            s.encode("utf-8")
+            if 'encode' in dir(s) else s
+            for s in row
+        ])
 
     def writerows(self, rows):
         for row in rows:
@@ -33,22 +36,12 @@ class CSVExporter(BaseExporter):
     preferred_formats = ('csv', 'string')
 
     def write(self, iterable, buff=None, *args, **kwargs):
-        header = []
         buff = self.get_file_obj(buff)
         writer = UnicodeWriter(buff, quoting=csv.QUOTE_MINIMAL)
 
-        for i, row_gen in enumerate(self.read(iterable, *args, **kwargs)):
-            row = []
+        writer.writerow([f['label'] for f in self.header])
 
-            for data in row_gen:
-                if i == 0:
-                    header.extend(data.keys())
-
-                row.extend(data.values())
-
-            if i == 0:
-                writer.writerow(header)
-
+        for row in iterable:
             writer.writerow(row)
 
         return buff

--- a/avocado/export/_html.py
+++ b/avocado/export/_html.py
@@ -18,7 +18,11 @@ class HTMLExporter(BaseExporter):
         if isinstance(template, basestring):
             template = get_template(template)
 
-        context = Context({'rows': self.read(iterable, *args, **kwargs)})
+        context = Context({
+            'header': self.header,
+            'rows': iterable,
+        })
+
         buff.write(template.render(context))
 
         return buff

--- a/avocado/export/_json.py
+++ b/avocado/export/_json.py
@@ -8,6 +8,7 @@ class JSONGeneratorEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if inspect.isgenerator(obj):
             return list(obj)
+
         return super(JSONGeneratorEncoder, self).default(obj)
 
 
@@ -25,7 +26,11 @@ class JSONExporter(BaseExporter):
 
         encoder = JSONGeneratorEncoder()
 
-        for chunk in encoder.iterencode(self.read(iterable, *args, **kwargs)):
+        keys = [f['name'] for f in self.header]
+
+        data = [dict(zip(keys, values)) for values in iterable]
+
+        for chunk in encoder.iterencode(data):
             buff.write(chunk)
 
         return buff

--- a/avocado/models.py
+++ b/avocado/models.py
@@ -662,21 +662,6 @@ class DataConcept(BasePlural, PublishArchiveMixin):
 
     objects = managers.DataConceptManager()
 
-    def format(self, *args, **kwargs):
-        """Convenience method for formatting data relative to this concept's
-        associated formatter. To prevent redundant initializations (say, in
-        a tight loop) the formatter instance is cached until the formatter
-        name changes.
-        """
-        name = self.formatter
-        cache = getattr(self, '_formatter_cache', None)
-        if not cache or name != cache[0]:
-            formatter = formatters.registry.get(name)(self)
-            self._formatter_cache = (name, formatter)
-        else:
-            formatter = cache[1]
-        return formatter(*args, **kwargs)
-
     class Meta(object):
         app_label = 'avocado'
         ordering = ('category__order', 'category__name', 'order', 'name')

--- a/avocado/query/pipeline.py
+++ b/avocado/query/pipeline.py
@@ -44,8 +44,7 @@ class QueryProcessor(object):
 
         if self.include_pk:
             pk_name = trees[self.tree].root_model._meta.pk.name
-            formatter = RawFormatter(keys=[pk_name])
-            exporter.add_formatter(formatter, index=0)
+            exporter.add_formatter(RawFormatter, keys=[pk_name], index=0)
 
         return exporter
 

--- a/tests/cases/formatters/tests.py
+++ b/tests/cases/formatters/tests.py
@@ -1,14 +1,7 @@
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
 from django.test import TestCase
 from django.core import management
 from avocado.models import DataField, DataConcept, DataConceptField
 from avocado.formatters import Formatter
-
-
-__all__ = ['FormatterTestCase']
 
 
 class FormatterTestCase(TestCase):
@@ -22,72 +15,81 @@ class FormatterTestCase(TestCase):
         boss_field = DataField.objects.get_by_natural_key(
             'tests', 'title', 'boss')
 
-        self.concept = concept = DataConcept(name='Title')
+        concept = DataConcept(name='Title')
         concept.save()
 
         DataConceptField(concept=concept, field=name_field, order=1).save()
         DataConceptField(concept=concept, field=salary_field, order=2).save()
         DataConceptField(concept=concept, field=boss_field, order=3).save()
 
+        self.concept = concept
         self.values = ['CEO', 100000, True]
-        self.f = Formatter(concept)
+
+    def test_fields(self):
+        f = Formatter(self.concept)
+
+        meta = f.get_meta()
+        header = meta['header']
+        self.assertEqual(3, len(header))
+
+        names = [x['name'] for x in header]
+        self.assertEqual(names, ['name', 'salary', 'boss'])
 
     def test_default(self):
-        fvalues = self.f(self.values)
-        self.assertEqual(OrderedDict([
-            ('name', 'CEO'),
-            ('salary', 100000),
-            ('boss', True),
-        ]), fvalues)
+        f = Formatter(self.concept)
+
+        fvalues = f(self.values)
+        expected = ('CEO', 100000, True)
+
+        self.assertEqual(fvalues, expected)
 
     def test_to_string(self):
-        fvalues = self.f(self.values, preferred_formats=['string'])
-        self.assertEqual(OrderedDict([
-            ('name', 'CEO'),
-            ('salary', '100000'),
-            ('boss', 'True'),
-        ]), fvalues)
+        f = Formatter(self.concept, formats=['string'])
+
+        fvalues = f(self.values)
+        expected = ('CEO', '100000', 'True')
+
+        self.assertEqual(fvalues, expected)
 
     def test_to_number(self):
-        fvalues = self.f(self.values, preferred_formats=['number'])
-        self.assertEqual(OrderedDict([
-            ('name', 'CEO'),
-            ('salary', 100000),
-            ('boss', 1),
-        ]), fvalues)
+        f = Formatter(self.concept, formats=['number'])
+
+        fvalues = f(self.values)
+        expected = ('CEO', 100000, 1)
+
+        self.assertEqual(fvalues, expected)
 
     def test_to_boolean(self):
-        fvalues = self.f(self.values, preferred_formats=['boolean'])
-        self.assertEqual(OrderedDict([
-            ('name', 'CEO'),
-            ('salary', 100000),
-            ('boss', True),
-        ]), fvalues)
+        f = Formatter(self.concept, formats=['boolean'])
+
+        fvalues = f(self.values)
+        expected = ('CEO', 100000, True)
+
+        self.assertEqual(fvalues, expected)
 
     def test_to_coded(self):
-        fvalues = self.f(self.values, preferred_formats=['coded'])
-        self.assertEqual(OrderedDict([
-            ('name', 'CEO'),
-            ('salary', 100000),
-            ('boss', 1),
-        ]), fvalues)
+        f = Formatter(self.concept, formats=['coded'])
+
+        fvalues = f(self.values)
+        expected = ('CEO', 100000, 1)
+
+        self.assertEqual(fvalues, expected)
 
     def test_to_html(self):
         class HtmlFormatter(Formatter):
             def to_html(self, values, **context):
-                fvalues = self(values, preferred_formats=['string'])
+                fvalues = [self.to_string(v, **context) for v in values]
 
-                return '<span>{0}</span>'.format(
-                    '</span><span>'.join(fvalues.values()))
+                return '<span>{0}</span>'.format('</span><span>'.join(fvalues))
 
             to_html.process_multiple = True
 
-        f = HtmlFormatter(self.concept)
-        fvalues = f(self.values, preferred_formats=['html'])
+        f = HtmlFormatter(self.concept, formats=['html'])
 
-        self.assertEqual(OrderedDict({
-            'Title': u'<span>CEO</span><span>100000</span><span>True</span>'
-        }), fvalues)
+        fvalues = f(self.values)
+        expected = (u'<span>CEO</span><span>100000</span><span>True</span>',)
+
+        self.assertEqual(fvalues, expected)
 
     def test_unique_keys(self):
         title_name = DataField.objects.get_by_natural_key(
@@ -102,9 +104,9 @@ class FormatterTestCase(TestCase):
         DataConceptField(concept=concept, field=title_name, order=1).save()
         DataConceptField(concept=concept, field=project_name, order=2).save()
 
-        f = Formatter(concept)
+        f = Formatter(concept=concept)
 
-        self.assertEqual(OrderedDict([
-            ('title__name', 'one'),
-            ('project__name', 'two'),
-        ]), f(['one', 'two']))
+        meta = f.get_meta()
+        names = [x['name'] for x in meta['header']]
+
+        self.assertEqual(names, ['title__name', 'project__name'])

--- a/tests/cases/models/tests.py
+++ b/tests/cases/models/tests.py
@@ -1,8 +1,4 @@
 from copy import deepcopy
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
 from django.test import TestCase
 from django.core import management
 from django.test.utils import override_settings
@@ -342,61 +338,6 @@ class DataFieldQuerysetTestCase(TestCase):
                         ('Eric', 1),
                         ('Erick', 1),
                         ('Erin', 1)))
-
-
-class DataConceptTestCase(TestCase):
-    def setUp(self):
-        management.call_command('avocado', 'init', 'tests', publish=False,
-                                concepts=False, quiet=True)
-
-    def test_format(self):
-        name_field = DataField.objects.get_by_natural_key(
-            'tests', 'title', 'name')
-        salary_field = DataField.objects.get_by_natural_key(
-            'tests', 'title', 'salary')
-        boss_field = DataField.objects.get_by_natural_key(
-            'tests', 'title', 'boss')
-
-        concept = DataConcept(name='Title')
-        concept.save()
-
-        DataConceptField(concept=concept, field=name_field, order=1).save()
-        DataConceptField(concept=concept, field=salary_field, order=2).save()
-        DataConceptField(concept=concept, field=boss_field, order=3).save()
-
-        values = ['CEO', 100000, True]
-
-        self.assertEqual(
-            concept.format(values),
-            OrderedDict([
-                (u'name', u'CEO'),
-                (u'salary', 100000),
-                (u'boss', True)
-            ]))
-
-        self.assertEqual(concept._formatter_cache[0], None)
-
-        from avocado.formatters import Formatter, registry as formatters
-
-        class HtmlFormatter(Formatter):
-            def to_html(self, values, **context):
-                fvalues = self(values, preferred_formats=['string'])
-                return OrderedDict({
-                    'profile': '<span>' +
-                               '</span><span>'.join(fvalues.values()) +
-                               '</span>'
-                })
-            to_html.process_multiple = True
-
-        formatters.register(HtmlFormatter, 'HTML')
-        concept.formatter = 'HTML'
-
-        self.assertEqual(
-            concept.format(values, preferred_formats=['html']),
-            OrderedDict([
-                ('profile',
-                 u'<span>CEO</span><span>100000</span><span>True</span>')
-            ]))
 
 
 class DataConceptManagerTestCase(TestCase):


### PR DESCRIPTION
A call to formatter(...) was doing a lot of work for every row being
processed. The primary slow spots are:

- Format methods being dynamically accessed via getattr() on every loop
- Unpacking keyword arguments (**kwargs) in the method call
- Building and moving OrderedDict values
- Logging a message when a value failed be coerced

To remediate these issues, targeted format methods are now processed
at initialization rather that process time. This requires the list of
formats to be passed into the constructor and not in the __call__ method.

Keyword arguments passed in during a call are no longer unpacked in the
method call, but are passed as a keyword argument itself, `kwargs`.

Use of OrderedDict has been removed altogether. These structures take up
a lot of memory and have proven to add little value during processing.
This required adding a method for getting the header/field data for the
values being processed. This is also a desirable change for addressing
#99 and #255.

Logging has been addressed by only doing while in DEBUG mode. Since the
exception is skipped, there is no point in logging the errors while in
production.

The exporters have been updated to accommodate this changes. In addition,
new read methods have been implemented for performance testing including
cached and threaded versions. The previous read method have been renamed
to manual_read since it performs manual limit and offsetting and distinct
checking.

To accommodate the new read method, the `write` on all exporters have been
changed to not call `read` itself. This change requires the passed iterable
to already contain the formatted rows.

Note: This refactor requires backwards incompatible changes to get the
performance gains.

Signed-off-by: Byron Ruth <b@devel.io>