### PR TITLE
Add header check to base exporter class

### DIFF
--- a/avocado/export/_base.py
+++ b/avocado/export/_base.py
@@ -1,7 +1,7 @@
 import functools
 from multiprocessing.pool import ThreadPool
 from avocado.models import DataView
-from avocado.formatters import registry as formatters
+from avocado.formatters import FormatterMismatchError, registry as formatters
 from cStringIO import StringIO
 
 
@@ -27,6 +27,7 @@ class BaseExporter(object):
         self.concepts = concepts
 
         self._header = []
+        self._header_checked = False
 
         for concept in concepts:
             formatter_class = formatters.get(concept.formatter)
@@ -62,15 +63,18 @@ class BaseExporter(object):
         header = meta['header']
 
         if index is not None:
-            self._header = (self._header[:index] +
-                            list(header) +
-                            self._header[index:])
+            self._header.insert(index, header)
         else:
-            self._header.extend(header)
+            self._header.append(header)
 
     @property
     def header(self):
-        return tuple(self._header)
+        header = []
+
+        for fields in self._header:
+            header.extend(fields)
+
+        return header
 
     def get_file_obj(self, name=None):
         if name is None:
@@ -81,17 +85,45 @@ class BaseExporter(object):
 
         return name
 
-    def _format_row(self, row, kwargs=None):
+    def _check_header(self, row, context):
+        self._header_checked = True
+
+        errors = []
+
+        # Compare the header fields with the row output.
+        for i, (formatter, length) in enumerate(self.params):
+            values, row = row[:length], row[length:]
+
+            fields = self._header[i]
+            output = formatter(values, context)
+
+            if len(fields) != len(output):
+                errors.append('Formatter "{0}" header is size {1}, '
+                              'but outputs a record of size {2} for '
+                              'concept "{3}"'
+                              .format(formatter, len(fields), len(output),
+                                      formatter.concept))
+
+        if errors:
+            raise FormatterMismatchError(errors)
+
+    def _format_row(self, row, context=None):
+        if not self._header_checked:
+            self._check_header(row, context)
+
         _row = []
 
         for formatter, length in self.params:
             values, row = row[:length], row[length:]
 
-            _row.extend(formatter(values, kwargs=kwargs))
+            _row.extend(formatter(values, context=context))
 
         return tuple(_row)
 
-    def _cache_format_row(self, row, kwargs=None):
+    def _cache_format_row(self, row, context=None):
+        if not self._header_checked:
+            self._check_header(row, context)
+
         _row = []
 
         for formatter, length in self.params:
@@ -100,7 +132,7 @@ class BaseExporter(object):
             key = (formatter, values)
 
             if key not in self._format_cache:
-                segment = formatter(values, kwargs=kwargs)
+                segment = formatter(values, context=context)
 
                 self._format_cache[key] = segment
             else:
@@ -112,8 +144,9 @@ class BaseExporter(object):
 
     def read(self, iterable, *args, **kwargs):
         "Reads an iterable and generates formatted rows."
+
         for row in iterable:
-            yield self._format_row(row, kwargs=kwargs)
+            yield self._format_row(row, context=kwargs)
 
     def cached_read(self, iterable, *args, **kwargs):
         """Reads an iterable and generates formatted rows.
@@ -128,7 +161,7 @@ class BaseExporter(object):
         self._format_cache = {}
 
         for row in iterable:
-            yield self._cache_format_row(row, kwargs=kwargs)
+            yield self._cache_format_row(row, context=kwargs)
 
     def threaded_read(self, iterable, threads=None, *args, **kwargs):
         """Reads an iterable and generates formatted rows.
@@ -139,7 +172,7 @@ class BaseExporter(object):
         pool = ThreadPool(threads)
 
         f = functools.partial(self._format_row,
-                              kwargs=kwargs)
+                              context=kwargs)
 
         for row in pool.map(f, iterable):
             yield row
@@ -155,7 +188,7 @@ class BaseExporter(object):
         pool = ThreadPool(threads)
 
         f = functools.partial(self._cache_format_row,
-                              kwargs=kwargs)
+                              context=kwargs)
 
         for row in pool.map(f, iterable):
             yield row
@@ -196,7 +229,7 @@ class BaseExporter(object):
             if offset is None or i >= offset:
                 emitted += 1
 
-                yield self._format_row(_row, kwargs=kwargs)
+                yield self._format_row(_row, context=kwargs)
 
     def write(self, iterable, *args, **kwargs):
         for row in iterable:

--- a/tests/cases/formatters/tests.py
+++ b/tests/cases/formatters/tests.py
@@ -77,8 +77,12 @@ class FormatterTestCase(TestCase):
 
     def test_to_html(self):
         class HtmlFormatter(Formatter):
-            def to_html(self, values, **context):
-                fvalues = [self.to_string(v, **context) for v in values]
+            def to_html(self, values, fields, context):
+                fvalues = []
+
+                for i, k in enumerate(fields):
+                    value = self.to_string(values[i], fields[k], context)
+                    fvalues.append(value)
 
                 return '<span>{0}</span>'.format('</span><span>'.join(fvalues))
 
@@ -86,10 +90,10 @@ class FormatterTestCase(TestCase):
 
         f = HtmlFormatter(self.concept, formats=['html'])
 
-        fvalues = f(self.values)
-        expected = (u'<span>CEO</span><span>100000</span><span>True</span>',)
+        output = f(self.values)
+        expected = u'<span>CEO</span><span>100000</span><span>True</span>'
 
-        self.assertEqual(fvalues, expected)
+        self.assertEqual(output[0], expected)
 
     def test_unique_keys(self):
         title_name = DataField.objects.get_by_natural_key(


### PR DESCRIPTION
The check uses the first row of data as input to validate the
shape of the header and row are the same.

The motivation behind this is to provide a bit more transparency
when an error is encountered during an export due to faulty
formatter.

In addition, the `to_FOO` formatter methods have been changed to
not take arbitrary positional or keyword arguments. The formatter
context represents the keyword arguments passed into the exporter
read method; typically included `request` and/or `user`.

Signed-off-by: Byron Ruth <b@devel.io>