### PR TITLE
Methods and jobs API to support async result retrieval

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch = True
 source = avocado
 omit =
     */admin.py
+    */south_migrations/*
     */migrations/*
     avocado/query/parsers/__init__.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 
 services:
     - memcached
+    - redis-server
 
 addons:
     - postgres

--- a/avocado/async/utils.py
+++ b/avocado/async/utils.py
@@ -1,0 +1,92 @@
+from django_rq import get_worker, get_queue
+
+from avocado.conf import settings
+from avocado.query import utils
+
+
+def run_jobs():
+    """
+    Execute all the pending jobs.
+    """
+    get_worker(settings.ASYNC_QUEUE).work(burst=True)
+
+
+def get_job(job_id):
+    """
+    Return the job for the specified ID or None if it cannot be found.
+
+    Args:
+        job_id(uuid): The ID of the job to retrieve.
+
+    Returns:
+        The job with the matching ID or None if no job with the supplied job
+        ID could be found.
+    """
+    queue = get_queue(settings.ASYNC_QUEUE)
+    return queue.fetch_job(job_id)
+
+
+def get_job_count():
+    """
+    Returns the current number of jobs in the queue.
+    """
+    return get_queue(settings.ASYNC_QUEUE).count
+
+
+def get_job_result(job_id):
+    """
+    Returns the result of the job with the supplied ID.
+
+    If the job could not be found or the job is not finished yet, None will
+    be returned as the job result.
+
+    Args:
+        job_id(uuid): The ID of the job to retrieve the result for.
+
+    Returns:
+        The result of the job with the matching ID or None if the job could
+        not be found or is not finished.
+    """
+    return get_job(job_id).result
+
+
+def get_jobs():
+    """
+    Returns a collection of all the pending jobs.
+    """
+    return get_queue(settings.ASYNC_QUEUE).jobs
+
+
+def cancel_job(job_id):
+    """
+    Cancel the job and its associated query if they exist.
+
+    Args:
+        job_id(uuid): The ID of the job to cancel
+
+    Returns:
+        The cancellation result of the job's query if it had one. If the job
+        could not be found or the job had no query, this method returns None.
+    """
+    job = get_job(job_id)
+
+    if job is None:
+        return None
+
+    result = None
+    query_name = job.meta.get('query_name')
+    if query_name:
+        canceled = utils.cancel_query(query_name)
+        result = {
+            'canceled': canceled
+        }
+
+    job.cancel()
+    return result
+
+
+def cancel_all_jobs():
+    """
+    Cancels all jobs.
+    """
+    get_queue(settings.ASYNC_QUEUE).empty()

--- a/avocado/conf/global_settings.py
+++ b/avocado/conf/global_settings.py
@@ -120,3 +120,6 @@ PERMISSIONS_ENABLED = None
 # the ad-hoc queries built from a context and view.
 DATA_CACHE = 'default'
 QUERY_CACHE = 'default'
+
+# Name of the queue to use for scheduling and working on async jobs.
+ASYNC_QUEUE = 'avocado'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ ordereddict
 sqlparse
 mysql-python
 psycopg2
+django_rq

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     'modeltree>=1.1.9',
     'South==1.0.2',
     'jsonfield==1.0.0',
+    'django_rq',
 ]
 
 if sys.version_info < (2, 7):

--- a/tests/processors.py
+++ b/tests/processors.py
@@ -1,0 +1,13 @@
+from avocado.models import DataContext
+from avocado.query.pipeline import QueryProcessor
+
+
+class ManagerQueryProcessor(QueryProcessor):
+    def __init__(self, *args, **kwargs):
+        kwargs['context'] = DataContext(json={
+            'field': 'tests.employee.is_manager',
+            'operator': 'exact',
+            'value': True,
+        })
+
+        super(ManagerQueryProcessor, self).__init__(*args, **kwargs)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django_rq',
     'haystack',
     'guardian',
 )
@@ -142,17 +143,26 @@ LOGGING = {
             'handlers': ['null'],
             'level': 'DEBUG',
             'propagate': True,
-        }
+        },
+        'rq.worker': {
+            'handlers': ['null'],
+            'level': 'DEBUG',
+        },
     }
 }
 
 SOUTH_TESTS_MIGRATE = False
 
+AVOCADO_QUEUE_NAME = 'avocado_test_queue'
 AVOCADO = {
     'HISTORY_ENABLED': False,
     'HISTORY_MAX_SIZE': 50,
     'METADATA_MIGRATION_APP': 'core',
     'DATA_CACHE_ENABLED': False,
+    'QUERY_PROCESSORS': {
+        'manager': 'tests.processors.ManagerQueryProcessor',
+    },
+    'ASYNC_QUEUE': AVOCADO_QUEUE_NAME,
 }
 
 MODELTREES = {
@@ -170,3 +180,11 @@ MODELTREES = {
 MIDDLEWARE_CLASSES = ()
 
 SECRET_KEY = 'acb123'
+
+RQ_QUEUES = {
+    AVOCADO_QUEUE_NAME: {
+        'HOST': 'localhost',
+        'PORT': 6379,
+        'DB': 0,
+    },
+}


### PR DESCRIPTION
@bruth cc @aaron0browne 

For more details, see conversation in https://github.com/chop-dbhi/serrano/pull/282. This should abstract the details of job creating and general job operations from users of the Avocado library. Given the current setup, changes required in other packages should be minimum if Avocado ever moves off `(django-)rq` in favor of a different job scheduler/worker platform.

TODO: 
 * [x] Add test coverage for code in this PR
 * [x] Fully document methods and API in this PR