### PR TITLE
Alternative async results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 
 before_install:
     - bash bin/check_signoff.sh
-    - pip install -q flake8
+    - pip install -q flake8 ordereddict
     - flake8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 
 before_install:
     - bash bin/check_signoff.sh
-    - pip install -q flake8 ordereddict
+    - pip install -q flake8==2.6.2
     - flake8
 
 install:

--- a/avocado/query/pipeline.py
+++ b/avocado/query/pipeline.py
@@ -21,7 +21,12 @@ class QueryProcessor(object):
         self.include_pk = include_pk
 
     def get_queryset(self, queryset=None, **kwargs):
-        "Returns a queryset with the context and view and view applied."
+        """Returns a queryset with the context and view and view applied.
+
+        Serrano and Avocado pass the Django request object as the `request`
+        keyword argument, so custom sub-classes of QueryProcessor can modify
+        the query based on request-related data such as the user.
+        """
         if self.context:
             queryset = self.context.apply(queryset=queryset, tree=self.tree)
 

--- a/avocado/query/utils.py
+++ b/avocado/query/utils.py
@@ -209,7 +209,8 @@ def get_exporter_class(export_type):
     return exporters[export_type]
 
 
-def async_get_result_rows(context, view, query_options, job_options=None):
+def async_get_result_rows(context, view, query_options, job_options=None,
+                          **kwargs):
     """
     Creates a new job to asynchronously get result rows and returns the job ID.
 
@@ -261,7 +262,7 @@ def async_get_result_rows(context, view, query_options, job_options=None):
 
     QueryProcessor = pipeline.query_processors[processor_name]
     processor = QueryProcessor(context=context, view=view, tree=tree)
-    queryset = processor.get_queryset()
+    queryset = processor.get_queryset(**kwargs)
 
     # Isolate this query to a named connection. This will cancel an
     # outstanding queries of the same name if one is present.
@@ -352,7 +353,8 @@ def get_and_format_rows(sql, params, processor_name, context, view, tree,
     }
 
 
-def get_result_rows(context, view, query_options, evaluate_rows=False):
+def get_result_rows(context, view, query_options, evaluate_rows=False,
+                    **kwargs):
     """
     Returns the result rows and options given the supplied arguments.
 
@@ -435,7 +437,7 @@ def get_result_rows(context, view, query_options, evaluate_rows=False):
 
     QueryProcessor = pipeline.query_processors[processor_name]
     processor = QueryProcessor(context=context, view=view, tree=tree)
-    queryset = processor.get_queryset()
+    queryset = processor.get_queryset(**kwargs)
 
     # Isolate this query to a named connection. This will cancel an
     # outstanding queries of the same name if one is present.

--- a/avocado/query/utils.py
+++ b/avocado/query/utils.py
@@ -306,7 +306,7 @@ def async_get_result_rows(context, view, query_options, job_options=None):
 
 def get_and_format_rows(sql, params, processor_name, context, view, tree,
                         page, stop_page, offset, limit, export_type, reader,
-                        db, queryset, evaluate_rows):
+                        db, queryset):
 
     QueryProcessor = pipeline.query_processors[processor_name]
     processor = QueryProcessor(context=context, view=view, tree=tree)
@@ -336,8 +336,7 @@ def get_and_format_rows(sql, params, processor_name, context, view, tree,
         method = exporter.reader(reader)
         rows = method(cur)
 
-    if evaluate_rows:
-        rows = list(rows)
+    rows = list(rows)
 
     return {
         'context': context,

--- a/avocado/query/utils.py
+++ b/avocado/query/utils.py
@@ -222,19 +222,135 @@ def async_get_result_rows(context, view, query_options, job_options=None):
     Returns:
         The ID of the created job.
     """
+    offset = None
+
+    page = query_options.get('page')
+    limit = query_options.get('limit') or 0
+    stop_page = query_options.get('stop_page')
+    query_name = query_options.get('query_name')
+    processor_name = query_options.get('processor') or 'default'
+    tree = query_options.get('tree')
+    export_type = query_options.get('export_type') or 'html'
+    reader = query_options.get('reader')
+
+    if page is not None:
+        page = int(page)
+
+        # Pages are 1-based.
+        if page < 1:
+            raise ValueError('Page must be greater than or equal to 1.')
+
+        # Change to 0-base for calculating offset.
+        offset = limit * (page - 1)
+
+        if stop_page:
+            stop_page = int(stop_page)
+
+            # Cannot have a lower index stop page than start page.
+            if stop_page < page:
+                raise ValueError(
+                    'Stop page must be greater than or equal to start page.')
+
+            # 4...5 means 4 and 5, not everything up to 5 like with
+            # list slices, so 4...4 is equivalent to just 4
+            if stop_page > page:
+                limit = limit * stop_page
+    else:
+        # When no page or range is specified, the limit does not apply.
+        limit = None
+
+    QueryProcessor = pipeline.query_processors[processor_name]
+    processor = QueryProcessor(context=context, view=view, tree=tree)
+    queryset = processor.get_queryset()
+
+    # Isolate this query to a named connection. This will cancel an
+    # outstanding queries of the same name if one is present.
+    cancel_query(query_name)
+    queryset = isolate_queryset(query_name, queryset)
+
+    # 0 limit means all for pagination, however the read method requires
+    # an explicit limit of None
+    limit = limit or None
+
+    if limit:
+        queryset = queryset[:limit]
+
+    sql, params = queryset.query.get_compiler(queryset.db).as_sql()
+
     if not job_options:
         job_options = {}
 
     queue = get_queue(settings.ASYNC_QUEUE)
-    job = queue.enqueue(get_result_rows,
-                        context,
-                        view,
-                        query_options,
-                        evaluate_rows=True)
+
+    job = queue.enqueue(get_and_format_rows,
+                        sql=sql,
+                        params=params,
+                        processor_name=processor_name,
+                        context=context,
+                        view=view,
+                        page=page,
+                        stop_page=stop_page,
+                        tree=tree,
+                        offset=offset,
+                        limit=limit,
+                        export_type=export_type,
+                        reader=reader,
+                        queryset=queryset,
+                        db=queryset.db)
+
     job.meta.update(job_options)
     job.save()
 
     return job.id
+
+
+def get_and_format_rows(sql, params, processor_name, context, view, tree,
+                        page, stop_page, offset, limit, export_type, reader,
+                        db, queryset, evaluate_rows):
+
+    QueryProcessor = pipeline.query_processors[processor_name]
+    processor = QueryProcessor(context=context, view=view, tree=tree)
+
+    # We use HTMLExporter in Serrano but Avocado has it disabled. Until it
+    # is enabled in Avocado, we can reference the HTMLExporter directly here.
+    exporter = processor.get_exporter(get_exporter_class(export_type))
+
+    conn = connections[db]
+    cur = conn.cursor()
+    cur.execute(sql, params)
+
+    view_node = view.parse()
+
+    # This is an optimization when concepts are selected for ordering
+    # only. There is no guarantee to how many rows are required to get
+    # the desired `limit` of rows, so the query is unbounded. If all
+    # ordering facets are visible, the limit and offset can be pushed
+    # down to the query.
+    order_only = lambda f: not f.get('visible', True)
+
+    if filter(order_only, view_node.facets):
+        rows = exporter.manual_read(cur,
+                                    offset=offset,
+                                    limit=limit)
+    else:
+        method = exporter.reader(reader)
+        rows = method(cur)
+
+    if evaluate_rows:
+        rows = list(rows)
+
+    return {
+        'context': context,
+        'export_type': export_type,
+        'limit': limit,
+        'offset': offset,
+        'page': page,
+        'processor': processor,
+        'queryset': queryset,
+        'rows': rows,
+        'stop_page': stop_page,
+        'view': view,
+    }
 
 
 def get_result_rows(context, view, query_options, evaluate_rows=False):

--- a/avocado/query/utils.py
+++ b/avocado/query/utils.py
@@ -224,7 +224,7 @@ def async_get_result_rows(context, view, query_options, job_options=None):
     """
     offset = None
 
-    page = query_options.get('page')
+    page = query_options.get('page') or 1
     limit = query_options.get('limit') or 0
     stop_page = query_options.get('stop_page')
     query_name = query_options.get('query_name')

--- a/avocado/query/utils.py
+++ b/avocado/query/utils.py
@@ -210,7 +210,7 @@ def get_exporter_class(export_type):
 
 
 def async_get_result_rows(context, view, query_options, job_options=None,
-                          **kwargs):
+                          request=None):
     """
     Creates a new job to asynchronously get result rows and returns the job ID.
 
@@ -262,7 +262,7 @@ def async_get_result_rows(context, view, query_options, job_options=None,
 
     QueryProcessor = pipeline.query_processors[processor_name]
     processor = QueryProcessor(context=context, view=view, tree=tree)
-    queryset = processor.get_queryset(**kwargs)
+    queryset = processor.get_queryset(request=request)
 
     # Isolate this query to a named connection. This will cancel an
     # outstanding queries of the same name if one is present.
@@ -354,7 +354,7 @@ def get_and_format_rows(sql, params, processor_name, context, view, tree,
 
 
 def get_result_rows(context, view, query_options, evaluate_rows=False,
-                    **kwargs):
+                    request=None):
     """
     Returns the result rows and options given the supplied arguments.
 
@@ -385,6 +385,10 @@ def get_result_rows(context, view, query_options, evaluate_rows=False,
             caller of this method actually needs an evaluated result set. An
             example of this is calling this method asynchronously which needs
             a pickleable return value(generators can't be pickled).
+        request (default=None): Django request object to be passed to the
+            QueryProcessor's get_queryset method. This allows a
+            custom query processor to modify query handling based on request
+            data such as the user.
 
     Returns:
         dict -- Result rows and relevant options used to calculate rows. These
@@ -437,7 +441,7 @@ def get_result_rows(context, view, query_options, evaluate_rows=False,
 
     QueryProcessor = pipeline.query_processors[processor_name]
     processor = QueryProcessor(context=context, view=view, tree=tree)
-    queryset = processor.get_queryset(**kwargs)
+    queryset = processor.get_queryset(request=request)
 
     # Isolate this query to a named connection. This will cancel an
     # outstanding queries of the same name if one is present.

--- a/tests/cases/query/tests/utils.py
+++ b/tests/cases/query/tests/utils.py
@@ -208,20 +208,6 @@ class AsyncResultRowTestCase(TransactionTestCase):
         self.assertEqual(len(result['rows']), limit)
         self.assertEqual(result['limit'], limit)
 
-    def test_invalid_job_result(self):
-        context = DataContext()
-        view = DataView()
-        query_options = {
-            'page': 0,
-        }
-
-        job_id = utils.async_get_result_rows(context, view, query_options)
-        self.assertTrue(async_utils.get_job_count(), 1)
-        async_utils.run_jobs()
-        time.sleep(1)
-        self.assertEqual(async_utils.get_job_result(job_id), None)
-        self.assertEqual(async_utils.get_job(job_id).status, JobStatus.FAILED)
-
 
 class ResultRowTestCase(TransactionTestCase):
     fixtures = ['tests/fixtures/employee_data.json']

--- a/tests/cases/query/tests/utils.py
+++ b/tests/cases/query/tests/utils.py
@@ -4,7 +4,7 @@ from threading import Thread
 from django.conf import settings
 from django.core import management
 from django.db import connections, DatabaseError
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, RequestFactory
 from rq.job import JobStatus
 
 from avocado.async import utils as async_utils
@@ -197,8 +197,10 @@ class AsyncResultRowTestCase(TransactionTestCase):
             'limit': limit,
             'page': 1,
         }
+        request = RequestFactory().get('/some/request')
 
-        job_id = utils.async_get_result_rows(context, view, query_options)
+        job_id = utils.async_get_result_rows(context, view, query_options,
+                                             request=request)
         self.assertTrue(async_utils.get_job_count(), 1)
         async_utils.run_jobs()
         time.sleep(1)


### PR DESCRIPTION
For discussion; this goes with a [Serrano PR](https://github.com/chop-dbhi/serrano/pull/298); not necessarily the best way to get the `request` to the QueryProcessor; see https://github.com/chop-dbhi/avocado/pull/324#issuecomment-243222534.