### PR TITLE
README was pointing to cilantro contributing instead of avocado

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ http://avocado.harvest.io
 
 ## Development
 
-See the [contributing](https://github.com/chop-dbhi/cilantro/blob/master/CONTRIBUTING.md) guide.
 See the [contributing](https://github.com/chop-dbhi/avocado/blob/master/CONTRIBUTING.md) guide.
 
 ## Data Model

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ http://avocado.harvest.io
 ## Development
 
 See the [contributing](https://github.com/chop-dbhi/cilantro/blob/master/CONTRIBUTING.md) guide.
+See the [contributing](https://github.com/chop-dbhi/avocado/blob/master/CONTRIBUTING.md) guide.
 
 ## Data Model
 


### PR DESCRIPTION
Minor link change to avocado repo instead of cilantro for the contributing agreement.