### PR TITLE
Change job cancellation to remove job from Redis also

### DIFF
--- a/avocado/async/utils.py
+++ b/avocado/async/utils.py
@@ -81,7 +81,7 @@ def cancel_job(job_id):
             'canceled': canceled
         }
 
-    job.cancel()
+    job.delete()
     return result
 
 
@@ -89,4 +89,5 @@ def cancel_all_jobs():
     """
     Cancels all jobs.
     """
-    get_queue(settings.ASYNC_QUEUE).empty()
+    for job in get_queue(settings.ASYNC_QUEUE).jobs:
+        job.delete()


### PR DESCRIPTION
This will fix [Serrano issue 299](https://github.com/chop-dbhi/serrano/issues/299). Once a job is canceled, it can no longer be found in or recovered from Redis.

Signed-off-by: Kevin Murphy <murphyke@email.chop.edu>